### PR TITLE
feat(gitignore): ignoring all files in bin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ Thumbs.db
 *.coverprofile
 
 .env
+bin


### PR DESCRIPTION
When developing locally files can accumulate in the bin dir. Add this dir to gitignore.